### PR TITLE
fixed scroll to bottom when new message, fixed send message on 'enter'

### DIFF
--- a/app/assets/stylesheets/components/_messages.scss
+++ b/app/assets/stylesheets/components/_messages.scss
@@ -85,6 +85,10 @@
   padding: 0.5rem;
   border: none;
   border-radius: 0.5rem;
+  
+  @media (max-width: 768px) {
+    height: 15%;
+  }
 }
 
 .container-chatbot {
@@ -92,7 +96,6 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100vh;
 }
 
 #new-question-form {

--- a/app/javascript/controllers/messages_modal_controller.js
+++ b/app/javascript/controllers/messages_modal_controller.js
@@ -7,7 +7,7 @@ export default class extends Controller {
   connect() {
     document.body.style.height = "100vh"
     document.body.style.overflow = "hidden"
-    this.containerTarget.scrollTo({ top: this.containerTarget.scrollHeight, behavior: "smooth" })
+    this.containerTarget.scrollTo({ top: this.containerTarget.scrollHeight })
   }
 
   disconnect() {

--- a/app/javascript/controllers/reset_form_controller.js
+++ b/app/javascript/controllers/reset_form_controller.js
@@ -1,7 +1,17 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
+  static targets = ["container"]
   reset() {
     this.element.reset()
+  }
+
+  handleEnter(event) {
+    if (event.key === 'Enter') {
+      this.element.submit()
+      this.containerTarget.scrollTo({
+        top: this.containerTarget.scrollHeight,
+      })
+    }
   }
 }

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -1,23 +1,17 @@
 <%= simple_form_for question, url: questions_path,
       html: { data: { controller: "reset-form", action: "turbo:submit-end->reset-form#reset" } } do |f| %>
   <div class="input-group mb-3 w-100">
-    <div class="form-floating">
-      <%= f.input :mother_question, label: false, wrapper: false %>
-      <%= f.label :mother_question, "Dites nous ce que vous voulez parler" %>
-    </div>
-    <%= f.submit "Envoyer", id: "new-question-button", class: "button-standard disabled" %>
+    <%= f.input :mother_question, 
+        label: false, 
+        wrapper: false, 
+        placeholder: "Dites nous ce que vous voulez parler", 
+        class: "form-control static-input",
+        input_html: { 
+          data: { 
+            action: "keydown->reset-form#handleEnter" 
+          },
+          rows: 1
+        } %>
+    <%= f.submit "Envoyer", id: "new-question-button", class: "button-standard" %>
   </div>
 <% end %>
-
-<script>
-  document.addEventListener('DOMContentLoaded', function() {
-    const formFloating = document.querySelector('.form-floating');
-    const newQuestionButton = document.getElementById('new-question-button');
-
-    if (formFloating.value === '') {
-      newQuestionButton.classList.add('disabled');
-    } else {
-      newQuestionButton.classList.remove('disabled');
-    }
-  });
-</script>


### PR DESCRIPTION
Scroll to bottom when new message sent. 
Tap "enter" to send new message.
Better alignment to the window of the chat window.